### PR TITLE
Switch to nmap-ncat in develop-with-pony image

### DIFF
--- a/develop-with-pony/Dockerfile
+++ b/develop-with-pony/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --update --no-cache \
   libressl-dev \
   lldb \
   make \
-  netcat-openbsd \
+  nmap-ncat \
   openssh \
   pcre2-dev \
   pinentry-tty \


### PR DESCRIPTION
It supports doing SSL which netcat-openbsd didn't.