### PR TITLE
Set POSTGRES_HOST environment variable in postgres environment

### DIFF
--- a/develop-postgres/Dockerfile
+++ b/develop-postgres/Dockerfile
@@ -4,3 +4,6 @@ LABEL org.opencontainers.image.source="https://github.com/seantallen/dev-environ
 
 RUN apk add --update --no-cache \
   docker
+
+# Set the postgres host to the host machine
+ENV POSTGRES_HOST=172.17.0.1


### PR DESCRIPTION
It is being set to the standard host address for docker so that the standard integration tests will be able to find the postgres container.